### PR TITLE
Spell "license" with an "s" consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ Example:
 
 Code entirely taken from
 [**@sjl**'s utilities](https://github.com/sjl/cl-losh/blob/master/losh.lisp),
-the original snippet to build the licence tree coming from a
+the original snippet to build the license tree coming from a
 **@dk_jackdaniel**'s [snippet](http://paste.lisp.org/display/327154).

--- a/print-licenses.asd
+++ b/print-licenses.asd
@@ -1,5 +1,5 @@
 ;; #|
-;;   This file is a part of print-licences project.
+;;   This file is a part of print-licenses project.
 ;; |#
 
 


### PR DESCRIPTION
I'm American so my original utility used the `license` spelling everywhere.  This repo mostly follows that, but there were a couple of places where `licence` was used: notably the filename of the `asd` file.