### PR TITLE
Added GROUP-BY-LICENSE argument + made function 1000 times faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ Example:
   uiop                 | Unspecified
 ~~~
 
+Or you might want to group systems by their license:
+
+~~~lisp
+  (print-licenses :fast-io
+                  :group-by-license t)
+  =>
+  MIT
+    babel, cffi, cffi-grovel, cffi-toolchain, fast-io, static-vectors, trivial-features, trivial-gray-streams
+
+  Public Domain / 0-clause MIT
+    alexandria
+
+  Unspecified
+    asdf, uiop
+~~~
+
 ## Credit
 
 Code entirely taken from

--- a/print-licenses.lisp
+++ b/print-licenses.lisp
@@ -124,10 +124,8 @@
        sys))))
 
 (defun license-list (quicklisp-project-designator)
-  (remove-duplicates
-    (mapcar (alexandria:rcurry #'coerce 'list)
-            (alexandria:flatten (license-tree quicklisp-project-designator)))
-    :key #'car :test #'string=))
+  (mapcar (alexandria:rcurry #'coerce 'list)
+          (alexandria:flatten (license-tree quicklisp-project-designator))))
 
 (defun print-licenses (quicklisp-project-designator)
   "Print the licenses used by the given project and its dependencies.


### PR DESCRIPTION
Here is an example of grouped output:

<img width="852" alt="Screen Shot 2022-04-12 at 03 15 26" src="https://user-images.githubusercontent.com/24827/162853448-90370170-ab22-4e2e-9cb6-5863ad2848f5.png">

Besides adding a way to group files by a license, this pull makes everything 1000 times faster by using a custom dependencies collection. This is especially noticeable when printing licenses for a system with a large dependency tree.

For example, before optimization for [Reblocks](https://github.com/40ants/reblocks) system `PRINT-LICENSES` function worked about 15 minutes:

```
Evaluation took:
  920.557 seconds of real time
  772.174653 seconds of total run time (258.725817 user, 513.448836 system)
  [ Run times consist of 7.051 seconds GC time, and 765.124 seconds non-GC time. ]
  83.88% CPU
  10,422,695 forms interpreted
  16 lambdas converted
  108,737,215,920 bytes consed
```

After optimizations, it returns in 1 second:

```
Evaluation took:
  0.947 seconds of real time
  0.802983 seconds of total run time (0.307298 user, 0.495685 system)
  [ Run times consist of 0.014 seconds GC time, and 0.789 seconds non-GC time. ]
  84.79% CPU
  7,344 forms interpreted
  16 lambdas converted
  128,026,304 bytes consed
```

Also, now ASDF subsystems are omitted if they has the same license is their primary system.